### PR TITLE
fix: delegated event handlers to support turbolinks

### DIFF
--- a/js/src/aside-menu.js
+++ b/js/src/aside-menu.js
@@ -63,7 +63,7 @@ const AsideMenu = (($) => {
     // Private
 
     _addEventListeners() {
-      $(Selector.ASIDE_MENU_TOGGLER).on(Event.CLICK, (event) => {
+      $(document).on(Event.CLICK, Selector.ASIDE_MENU_TOGGLER, (event) => {
         event.preventDefault()
         event.stopPropagation()
         const toggle = event.currentTarget.dataset.toggle

--- a/js/src/sidebar.js
+++ b/js/src/sidebar.js
@@ -139,27 +139,27 @@ const Sidebar = (($) => {
     // Private
 
     _addEventListeners() {
-      $(Selector.BRAND_MINIMIZER).on(Event.CLICK, (event) => {
+      $(document).on(Event.CLICK, Selector.BRAND_MINIMIZER, (event) => {
         event.preventDefault()
         event.stopPropagation()
         $(Selector.BODY).toggleClass(ClassName.BRAND_MINIMIZED)
       })
 
-      $(Selector.NAV_DROPDOWN_TOGGLE).on(Event.CLICK, (event) => {
+      $(document).on(Event.CLICK, Selector.NAV_DROPDOWN_TOGGLE, (event) => {
         event.preventDefault()
         event.stopPropagation()
         const dropdown = event.target
         $(dropdown).parent().toggleClass(ClassName.OPEN)
       })
 
-      $(Selector.SIDEBAR_MINIMIZER).on(Event.CLICK, (event) => {
+      $(document).on(Event.CLICK, Selector.SIDEBAR_MINIMIZER, (event) => {
         event.preventDefault()
         event.stopPropagation()
         $(Selector.BODY).toggleClass(ClassName.SIDEBAR_MINIMIZED)
         this.perfectScrollbar(Event.TOGGLE)
       })
 
-      $(Selector.SIDEBAR_TOGGLER).on(Event.CLICK, (event) => {
+      $(document).on(Event.CLICK, Selector.SIDEBAR_TOGGLER, (event) => {
         event.preventDefault()
         event.stopPropagation()
         const toggle = event.currentTarget.dataset.toggle


### PR DESCRIPTION
This fixes a bug that occurs when using core UI with [turbolinks](https://github.com/turbolinks/turbolinks).

Core UI's event handlers were being "lost" when turbolinks performs its partial page replacement, resulting in a loss of sidebar/aside functionality. This PR switches to delegated event handlers, fixing the issue.

I didn't rebuild the dist since I'm not sure what your release process is. Please let me know if you'd like me to rebuild dist.