### PR TITLE
chore: dependencies update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## v2.1.14
+
+###### Dependencies update:
+- update `rollup` to `^1.15.4`
+- update `rollup-plugin-node-resolve` to `^5.0.2` 
+
 ## v2.1.12
 - fix(scss): new mobile breakpoint variables
 ```scss

--- a/package-lock.json
+++ b/package-lock.json
@@ -6271,13 +6271,13 @@
       }
     },
     "rollup": {
-      "version": "1.15.1",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-1.15.1.tgz",
-      "integrity": "sha512-JErZxFKs0w7wpHZXWonAlom1Jezo0gJ7mf7JHTjOAjFGKAqNMEnlzEjMYhy6cqHgSfSPj/idVscuW+Lo6y6AoQ==",
+      "version": "1.15.4",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-1.15.4.tgz",
+      "integrity": "sha512-EjdjLZ6K5z3J7NkboB+aPVBthZt1CexD7u0IIcc7NYGoXAFyV6AbdKrS8elfwGNrYmuBC5ZDOSOzwH9Ad4PQKg==",
       "dev": true,
       "requires": {
         "@types/estree": "0.0.39",
-        "@types/node": "^12.0.7",
+        "@types/node": "^12.0.8",
         "acorn": "^6.1.1"
       },
       "dependencies": {
@@ -6313,9 +6313,9 @@
       }
     },
     "rollup-plugin-node-resolve": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/rollup-plugin-node-resolve/-/rollup-plugin-node-resolve-5.0.1.tgz",
-      "integrity": "sha512-9s3dTu44SKQZM/Pwll42GpqXgT+WdvO0Ga01lF8cwZqJGqRUATtD+GrP3uIzZdpnbPonEJbVasfFt80VGPQqKw==",
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-node-resolve/-/rollup-plugin-node-resolve-5.0.2.tgz",
+      "integrity": "sha512-/KMxyYDSMoeE+06CwbbPD8gwYcU9uwyOgMjfw2MJPDmwzEw24HIur9TR80SMsUjP2QCLSZ9othB65xNHN3e0gw==",
       "dev": true,
       "requires": {
         "@types/resolve": "0.0.8",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coreui/coreui",
-  "version": "2.1.12",
+  "version": "2.1.14",
   "description": "Open Source UI Kit built on top of Bootstrap 4",
   "keywords": [
     "bootstrap",
@@ -99,10 +99,10 @@
     "npm-run-all": "^4.1.5",
     "postcss-cli": "^6.1.2",
     "rimraf": "^2.6.3",
-    "rollup": "^1.15.1",
+    "rollup": "^1.15.4",
     "rollup-plugin-babel": "^4.3.2",
     "rollup-plugin-commonjs": "^10.0.0",
-    "rollup-plugin-node-resolve": "^5.0.1",
+    "rollup-plugin-node-resolve": "^5.0.2",
     "semver": "^6.1.1",
     "shelljs": "^0.8.3",
     "shx": "^0.3.2",


### PR DESCRIPTION
- update `rollup` to `^1.15.4`
- update `rollup-plugin-node-resolve` to `^5.0.2`