### PR TITLE
Flex direction column, with or without .c-wrapper-fluid

### DIFF
--- a/scss/layouts/_default.scss
+++ b/scss/layouts/_default.scss
@@ -30,7 +30,6 @@
     }
 
     .c-body {
-      flex-direction: column;
       overflow-y: auto;
     }
   }
@@ -46,7 +45,7 @@
 
 .c-body {
   display: flex;
-  flex-direction: row;
+  flex-direction: column;
   flex-grow: 1;
 }
 


### PR DESCRIPTION
Using the default layout, when I apply `.c-wrapper-fluid` to `.c-wrapper`, the layout gets messed up. Unless the HTML structure is supposed to be different in this scenario, I believe `.c-body` should have `flex-direction: column` in both cases for the sticky footer to work.

Additionally, the fixed header covers the contents when `.c-wrapper-fluid` is applied. I suppose it should be up to the user to compensate for this (by applying padding to `.c-main`), since headers can be different heights.