### PR TITLE
fix a sass call to lighten() function

### DIFF
--- a/scss/variables/components/_custom-forms.scss
+++ b/scss/variables/components/_custom-forms.scss
@@ -132,7 +132,7 @@ $custom-select-focus-border-color:  $input-focus-border-color !default;
 
 $custom-range-track-bg:           $gray-300 !default;
 $custom-range-thumb-bg:           $component-active-bg !default;
-$custom-range-thumb-active-bg:    ghten($component-active-bg, 35%) !default;
+$custom-range-thumb-active-bg:    lighten($component-active-bg, 35%) !default;
 $custom-range-thumb-disabled-bg:  $gray-500 !default;
 
 $custom-file-focus-border-color:  $input-focus-border-color !default;


### PR DESCRIPTION
A simple typo fix. currently calls ghten(), changed to lighten()

My build with the coreui-pro repository v3.0.3 was broken because of this.

I do not have access to the pro repo, but its also a problem here. Hoping that it gets fixed in pro as well.