### PR TITLE
Tackle issues caused by base64 stylesheet

### DIFF
--- a/js/src/utilities/get-css-custom-properties.js
+++ b/js/src/utilities/get-css-custom-properties.js
@@ -10,15 +10,19 @@ const getCssCustomProperties = () => {
   const sheets = document.styleSheets
   let cssText = ''
   for (let i = sheets.length - 1; i > -1; i--) {
-    const rules = sheets[i].cssRules
-    for (let j = rules.length - 1; j > -1; j--) {
-      if (rules[j].selectorText === '.ie-custom-properties') {
-        cssText = rules[j].cssText
+    try {
+      const rules = sheets[i].cssRules
+      for (let j = rules.length - 1; j > -1; j--) {
+        if (rules[j].selectorText === '.ie-custom-properties') {
+          cssText = rules[j].cssText
+          break
+        }
+      }
+      if (cssText) {
         break
       }
-    }
-    if (cssText) {
-      break
+    } catch (e) {
+      // Ignore error
     }
   }
 


### PR DESCRIPTION
for stylesheets injected by such as cloudflare like
`<link rel="stylesheet" href="data:text/css;charset=utf-8;base64,Y2xvdWRmbGFyZS1`

the script throws access denied error in ie11
The follow pr introduces a way of tackling it by simply ignoring it.
or the whole page stops rendering at the uncaught error.
