### PR TITLE
fix: keep margin-bottom for card-group and card-deck

### DIFF
--- a/css/card.css
+++ b/css/card.css
@@ -172,7 +172,6 @@ html:not([dir="rtl"]) .card-link + .card-link {
   .card-deck .card {
     flex: 1 0 0%;
     margin-right: 15px;
-    margin-bottom: 0;
     margin-left: 15px;
   }
 }
@@ -188,7 +187,6 @@ html:not([dir="rtl"]) .card-link + .card-link {
   }
   .card-group > .card {
     flex: 1 0 0%;
-    margin-bottom: 0;
   }
   html:not([dir="rtl"]) .card-group > .card + .card {
     margin-left: 0;

--- a/scss/_card.scss
+++ b/scss/_card.scss
@@ -203,7 +203,6 @@
       // Flexbugs #4: https://github.com/philipwalton/flexbugs#flexbug-4
       flex: 1 0 0%;
       margin-right: $card-deck-margin;
-      margin-bottom: 0; // Override the default
       margin-left: $card-deck-margin;
     }
   }
@@ -229,7 +228,6 @@
     > .card {
       // Flexbugs #4: https://github.com/philipwalton/flexbugs#flexbug-4
       flex: 1 0 0%;
-      margin-bottom: 0;
 
       + .card {
         @include ltr {


### PR DESCRIPTION
I am working on a project where I use Cards and Card-groups alongside each other and I noticed the Bottom margin is set to 0 for Cards located inside Card-groups or Card-decks, which messes with the alignment.
Now it requires an extra layer of <div> to align them properly, it would be nice to keep the 15px Bottom margin so that Cards and Card-groups can be used together seamlessly.