### PR TITLE
Fixes deprecation warnings about bg-variant on 3.4.0.

### DIFF
--- a/scss/utilities/_background.scss
+++ b/scss/utilities/_background.scss
@@ -26,11 +26,11 @@
 }
 
 @each $color, $value in $brands-colors {
-  @include bg-variant(".bg-#{$color}", $value);
+  @include bg-variant(".bg-#{$color}", $value, true);
 }
 
 @each $color, $value in $grays {
-  @include bg-variant(".bg-gray-#{$color}", $value);
+  @include bg-variant(".bg-gray-#{$color}", $value, true);
 }
 
 .bg-box {


### PR DESCRIPTION
Re-applying dea36c950956513732ebc2ab7a223a4ce4d91bd5
The warnings are (maybe accidentally) back again on a8db7aac538bab33f83ee5b918ead8a44105dcb8

Related to #154
