### PR TITLE
fix: `css/themes/bootstrap` missing from npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -153,7 +153,7 @@
     "vnu-jar": "23.4.11"
   },
   "files": [
-    "dist/{css,js}/*.{css,js,map}",
+    "dist/{css,js}/**/*.{css,js,map}",
     "js/{src,dist}/**/*.{js,map}",
     "js/index.{esm,umd}.js",
     "scss/**/*.scss",


### PR DESCRIPTION
from <https://coreui.io/bootstrap/docs/getting-started/introduction/#bootstrap-replacement>:
```html
<link href="https://cdn.jsdelivr.net/npm/@coreui/coreui@5.0.2/dist/css/themes/bootstrap/bootstrap.min.css" rel="stylesheet" integrity="sha384-3izbQ9DYR6+0wPQXIObC8C8MW9PaGjuNb/Uug0nW/tf3Yf+nnT+Ta1yxHSdzYLlw" crossorigin="anonymous">
```
the href uri returns an error as the file doesn't exist (it isn't included when published).

this is a tiny PR so feel free to close