### PR TITLE
Fix depreciated unit-less function call

### DIFF
--- a/scss/_functions.scss
+++ b/scss/_functions.scss
@@ -204,12 +204,12 @@ $_luminance-list: .0008 .001 .0011 .0013 .0015 .0017 .002 .0022 .0025 .0027 .003
 // scss-docs-start color-functions
 // Tint a color: mix a color with white
 @function tint-color($color, $weight) {
-  @return mix(white, $color, $weight);
+  @return mix(white, $color, percentage($weight));
 }
 
 // Shade a color: mix a color with black
 @function shade-color($color, $weight) {
-  @return mix(black, $color, $weight);
+  @return mix(black, $color, percentage($weight));
 }
 
 // Shade the color if the weight is positive, else tint it


### PR DESCRIPTION
Fixes https://github.com/coreui/coreui/issues/498
Fixes https://github.com/coreui/coreui/issues/598

```
[build:frontend:dev] ▲ [WARNING] $weight: Passing a number without unit % (70) is deprecated.
[build:frontend:dev]
[build:frontend:dev] To preserve current behavior: $weight * 1%
[build:frontend:dev]
[build:frontend:dev] More info: https://sass-lang.com/d/function-units [plugin sass-plugin]
[build:frontend:dev]
[build:frontend:dev]     ../../../node_modules/@coreui/coreui-pro/scss/_functions.scss:206:10:
[build:frontend:dev]       206 │ mix(white, $color, $weight)
```

The documentation talks about this as a breaking change here:
https://sass-lang.com/documentation/breaking-changes/function-units/#weight

We're using:
```
    "esbuild-sass-plugin": "^3.3.1",
```
