### PR TITLE
Fix var invalid pseudo element in _form-select.scss

### DIFF
--- a/scss/forms/_form-select.scss
+++ b/scss/forms/_form-select.scss
@@ -26,7 +26,7 @@
   @include transition($form-select-transition);
 
   &:focus {
-    border-color: var($form-select-focus-border-color);
+    border-color: $form-select-focus-border-color;
     outline: 0;
     @if $enable-shadows {
       @include box-shadow($form-select-box-shadow, $form-select-focus-box-shadow);


### PR DESCRIPTION
Fix pseudo element error for sass
```
border-color: var($form-select-focus-border-color);
```
to 
```
border-color: $form-select-focus-border-color;
```