### PR TITLE
fix: Handle when sidebar is hidden by other means than the "hide" class.

### DIFF
--- a/js/src/sidebar.js
+++ b/js/src/sidebar.js
@@ -8,7 +8,7 @@
 import BaseComponent from './base-component.js'
 import EventHandler from './dom/event-handler.js'
 import Manipulator from './dom/manipulator.js'
-import { defineJQueryPlugin } from './util/index.js'
+import { defineJQueryPlugin, isVisible } from './util/index.js'
 import Backdrop from './util/backdrop.js'
 import ScrollBarHelper from './util/scrollbar.js'
 
@@ -228,6 +228,10 @@ class Sidebar extends BaseComponent {
   }
 
   _isVisible() {
+    if (!isVisible(this._element)) {
+      return false
+    }
+
     const rect = this._element.getBoundingClientRect()
     return (
       rect.top >= 0 && rect.left >= 0 && Math.floor(rect.bottom) <= (window.innerHeight || document.documentElement.clientHeight) && Math.floor(rect.right) <= (window.innerWidth || document.documentElement.clientWidth)


### PR DESCRIPTION
Otherwise a hidden sidebar will e.g. block click events in mobile mode.