### PR TITLE
feat(Chip): chip-input ArrowRight→input + RTL arrow-key navigation

### DIFF
--- a/js/src/chip-input.js
+++ b/js/src/chip-input.js
@@ -11,7 +11,7 @@
 import ChipSet from './chip-set.js'
 import EventHandler from './dom/event-handler.js'
 import SelectorEngine from './dom/selector-engine.js'
-import { getUID } from './util/index.js'
+import { getUID, isRTL } from './util/index.js'
 
 /**
  * Constants
@@ -161,9 +161,10 @@ class ChipInput extends ChipSet {
         return
       }
 
-      // ArrowRight past the last chip moves focus into the text field
-      // (mirrors ArrowLeft from the start of the input focusing the last chip).
-      if (event.key === 'ArrowRight') {
+      // The arrow key past the last chip moves focus into the text field, which
+      // sits after the chips (mirrors the input's "go to last chip" key). The
+      // direction is mirrored in RTL.
+      if (event.key === (isRTL() ? 'ArrowLeft' : 'ArrowRight')) {
         const chips = this._getFocusableChips()
         if (chips.length > 0 && chips.at(-1).contains(event.target)) {
           event.preventDefault()
@@ -277,8 +278,16 @@ class ChipInput extends ChipSet {
         break
       }
 
-      case 'ArrowLeft': {
-        if (this._input.selectionStart === 0 && this._input.selectionEnd === 0) {
+      case 'ArrowLeft':
+      case 'ArrowRight': {
+        // The arrow pointing toward the chips (left in LTR, right in RTL) jumps
+        // to the last chip when the caret is at the start of the input.
+        const towardChipsKey = isRTL() ? 'ArrowRight' : 'ArrowLeft'
+        if (
+          key === towardChipsKey &&
+          this._input.selectionStart === 0 &&
+          this._input.selectionEnd === 0
+        ) {
           event.preventDefault()
           const chips = this._getChipElements()
 

--- a/js/src/chip-input.js
+++ b/js/src/chip-input.js
@@ -161,6 +161,17 @@ class ChipInput extends ChipSet {
         return
       }
 
+      // ArrowRight past the last chip moves focus into the text field
+      // (mirrors ArrowLeft from the start of the input focusing the last chip).
+      if (event.key === 'ArrowRight') {
+        const chips = this._getFocusableChips()
+        if (chips.length > 0 && chips.at(-1).contains(event.target)) {
+          event.preventDefault()
+          this._input.focus()
+          return
+        }
+      }
+
       if (event.key.length === 1) {
         this._input.focus()
       }

--- a/js/src/chip-set.js
+++ b/js/src/chip-set.js
@@ -10,7 +10,7 @@ import Chip from './chip.js'
 import EventHandler from './dom/event-handler.js'
 import Manipulator from './dom/manipulator.js'
 import SelectorEngine from './dom/selector-engine.js'
-import { defineJQueryPlugin, getNextActiveElement } from './util/index.js'
+import { defineJQueryPlugin, getNextActiveElement, isRTL } from './util/index.js'
 
 /**
  * Constants
@@ -370,13 +370,14 @@ class ChipSet extends BaseComponent {
     switch (event.key) {
       case 'ArrowLeft': {
         event.preventDefault()
-        this._focusSibling(chip, false)
+        // In RTL the visual direction is mirrored, so ArrowLeft moves to the next chip.
+        this._focusSibling(chip, isRTL())
         break
       }
 
       case 'ArrowRight': {
         event.preventDefault()
-        this._focusSibling(chip, true)
+        this._focusSibling(chip, !isRTL())
         break
       }
 

--- a/js/tests/unit/chip-input.spec.js
+++ b/js/tests/unit/chip-input.spec.js
@@ -1009,4 +1009,25 @@ describe('ChipInput', () => {
       expect(ChipInput.getOrCreateInstance(el)).toBeInstanceOf(ChipInput)
     })
   })
+
+  describe('keyboard navigation', () => {
+    it('should move focus to the input on ArrowRight from the last chip', () => {
+      fixtureEl.innerHTML = '<div class="chip-input"></div>'
+
+      const el = fixtureEl.querySelector('.chip-input')
+      const chipInput = new ChipInput(el)
+
+      chipInput.add('React')
+      chipInput.add('Vue')
+
+      const chips = el.querySelectorAll('.chip')
+      const lastChip = chips[chips.length - 1]
+      const input = el.querySelector('input.chip-input-field')
+      lastChip.focus()
+
+      lastChip.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowRight', bubbles: true }))
+
+      expect(document.activeElement).toEqual(input)
+    })
+  })
 })

--- a/js/tests/unit/chip-input.spec.js
+++ b/js/tests/unit/chip-input.spec.js
@@ -1029,5 +1029,28 @@ describe('ChipInput', () => {
 
       expect(document.activeElement).toEqual(input)
     })
+
+    it('should move focus to the input on ArrowLeft from the last chip in RTL', () => {
+      document.documentElement.dir = 'rtl'
+
+      fixtureEl.innerHTML = '<div class="chip-input"></div>'
+
+      const el = fixtureEl.querySelector('.chip-input')
+      const chipInput = new ChipInput(el)
+
+      chipInput.add('React')
+      chipInput.add('Vue')
+
+      const chips = el.querySelectorAll('.chip')
+      const lastChip = chips[chips.length - 1]
+      const input = el.querySelector('input.chip-input-field')
+      lastChip.focus()
+
+      lastChip.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowLeft', bubbles: true }))
+
+      expect(document.activeElement).toEqual(input)
+
+      document.documentElement.dir = ''
+    })
   })
 })

--- a/js/tests/unit/chip-set.spec.js
+++ b/js/tests/unit/chip-set.spec.js
@@ -138,6 +138,25 @@ describe('ChipSet', () => {
       expect(document.activeElement).toEqual(chips[1])
     })
 
+    it('should mirror arrow keys in RTL', () => {
+      document.documentElement.dir = 'rtl'
+
+      const el = setMarkup(['First', 'Second'])
+      // eslint-disable-next-line no-new
+      new ChipSet(el, { selectable: true })
+
+      const chips = el.querySelectorAll('.chip')
+      chips[0].focus()
+      // In RTL, ArrowLeft moves to the next chip.
+      chips[0].dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowLeft', bubbles: true }))
+      expect(document.activeElement).toEqual(chips[1])
+
+      chips[1].dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowRight', bubbles: true }))
+      expect(document.activeElement).toEqual(chips[0])
+
+      document.documentElement.dir = ''
+    })
+
     it('should focus first chip on Home key', () => {
       const el = setMarkup()
       // eslint-disable-next-line no-new


### PR DESCRIPTION
Two related chip keyboard-navigation improvements.

## 1. ArrowRight past the last chip focuses the input

The chip set's roving focus stops at the edges, so ArrowRight on the **last** chip did nothing. The text field sits after the chips, so focus now advances into it — symmetric with ArrowLeft at the start of the input focusing the last chip.

## 2. RTL arrow-key navigation

Arrow keys now mirror left/right when the chip set renders right-to-left (`dir="rtl"`): roving focus between chips, ArrowRight-into-the-input from the last chip, and ArrowLeft-to-the-last-chip from the input all swap. Uses the existing `isRTL()` util (matching e.g. Carousel). Standalone LTR behavior unchanged.

Unit tests added for both.