### PR TITLE
docs: fix broken internal links (base-relative helpers/accessibility)

### DIFF
--- a/docs/src/content/docs/components/card.mdx
+++ b/docs/src/content/docs/components/card.mdx
@@ -379,7 +379,7 @@ Cards include various options for customizing their backgrounds, borders, and co
 
 <AddedIn version="4.2.6" />
 
-Set a `background-color` with contrasting foreground `color` with [our `.text-bg-{color}` helpers](helpers/color-background/). Previously it was required to manually pair your choice of [`.text-{color}`](/utilities/colors/) and [`.bg-{color}`](/utilities/background/) utilities for styling, which you still may use if you prefer.
+Set a `background-color` with contrasting foreground `color` with [our `.text-bg-{color}` helpers](/helpers/color-background/). Previously it was required to manually pair your choice of [`.text-{color}`](/utilities/colors/) and [`.bg-{color}`](/utilities/background/) utilities for styling, which you still may use if you prefer.
 
 <Example code={getData('theme-colors').map((c) => `<div class="card text-bg-${c.name} mb-3" style="max-width: 18rem;">
     <div class="card-header">Header</div>

--- a/docs/src/content/docs/utilities/link.mdx
+++ b/docs/src/content/docs/utilities/link.mdx
@@ -8,7 +8,7 @@ import { getData } from '@coreui/astro-docs/data'
 
 ## Link opacity
 
-Change the alpha opacity of the link `rgba()` color value with utilities. Please be aware that changes to a color's opacity can lead to links with [*insufficient* contrast](getting-started/accessibility/#color-contrast).
+Change the alpha opacity of the link `rgba()` color value with utilities. Please be aware that changes to a color's opacity can lead to links with [*insufficient* contrast](/getting-started/accessibility/#color-contrast).
 
 <Example code={`<p><a class="link-opacity-10" href="#">Link opacity 10</a></p>
   <p><a class="link-opacity-25" href="#">Link opacity 25</a></p>


### PR DESCRIPTION
Fixes two broken internal links surfaced by astro-broken-links-checker by making them base-relative:
- `components/card` -> `helpers/color-background/` -> `/helpers/color-background/`
- `utilities/link` -> `getting-started/accessibility/#color-contrast` -> `/getting-started/accessibility/#color-contrast`