### PR TITLE
chore(docs): bump @coreui/astro-docs to 0.1.0-beta.12

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "@astrojs/mdx": "^6.0.3",
         "@babel/core": "^7.29.7",
         "@babel/preset-env": "^7.29.7",
-        "@coreui/astro-docs": "^0.1.0-beta.9",
+        "@coreui/astro-docs": "0.1.0-beta.12",
         "@eslint/markdown": "^7.5.1",
         "@popperjs/core": "^2.11.8",
         "@rollup/plugin-babel": "^7.1.0",
@@ -1885,9 +1885,9 @@
       }
     },
     "node_modules/@coreui/astro-docs": {
-      "version": "0.1.0-beta.9",
-      "resolved": "https://registry.npmjs.org/@coreui/astro-docs/-/astro-docs-0.1.0-beta.9.tgz",
-      "integrity": "sha512-PS4WfpM/HtHFb8pNwFSr3tRPSxN1xz+reUzg+cOs4wUoUvaEZPLhplwAAHOL73W+kZKgGvcJ1mRFP+Pn4noPxA==",
+      "version": "0.1.0-beta.12",
+      "resolved": "https://registry.npmjs.org/@coreui/astro-docs/-/astro-docs-0.1.0-beta.12.tgz",
+      "integrity": "sha512-jP22c6+9SxnAJz5Og30hEBNmnB5cIpFfxQHSZHU4qapXTVvHDG0lvTDExs+H+fGytq478G2qODf+nn3A87l6lg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1898,14 +1898,16 @@
         "@docsearch/js": "^4.6.3",
         "@stackblitz/sdk": "^1.11.0",
         "astro-auto-import": "^0.5.1",
-        "js-yaml": "^4.2.0",
+        "astro-broken-links-checker": "^1.1.0",
+        "js-yaml": "^4.3.0",
         "lz-string": "^1.5.0",
         "rehype-autolink-headings": "^7.1.0",
         "unist-util-visit": "^5.1.0",
         "zod": "^4.4.3"
       },
       "peerDependencies": {
-        "astro": ">=6"
+        "@astrojs/mdx": "^6.0.0",
+        "astro": "^6.4.0"
       }
     },
     "node_modules/@coreui/icons": {
@@ -5319,6 +5321,50 @@
       },
       "peerDependencies": {
         "astro": "^5.0.0-beta || ^6.0.0-alpha"
+      }
+    },
+    "node_modules/astro-broken-links-checker": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/astro-broken-links-checker/-/astro-broken-links-checker-1.1.0.tgz",
+      "integrity": "sha512-TYfDUZl0iYq1dVZO+R0appTBkDmSMsOrafgWJMGqoD4xVd74imTRdzekE6tA8+6AIi+/GXMGlr/im0unLD1LRg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "fast-glob": "^3.3.3",
+        "node-html-parser": "^7.0.1",
+        "p-limit": "^7.2.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/astro-broken-links-checker/node_modules/p-limit": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-7.3.0.tgz",
+      "integrity": "sha512-7cIXg/Z0M5WZRblrsOla88S4wAK+zOQQWeBYfV3qJuJXMr+LnbYjaadrFaS0JILfEDPVqHyKnZ1Z/1d6J9VVUw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "yocto-queue": "^1.2.1"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/astro-broken-links-checker/node_modules/yocto-queue": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-1.2.2.tgz",
+      "integrity": "sha512-4LCcse/U2MHZ63HAJVE+v71o7yOdIe4cZ70Wpf8D/IyjDKYQLV5GD46B+hSTjJsvV5PztjvHoU580EftxjDZFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/astro/node_modules/cookie": {
@@ -9119,6 +9165,16 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/he": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
+      "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "he": "bin/he"
+      }
+    },
     "node_modules/hookified": {
       "version": "1.15.1",
       "resolved": "https://registry.npmjs.org/hookified/-/hookified-1.15.1.tgz",
@@ -10355,9 +10411,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
-      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
       "dev": true,
       "funding": [
         {
@@ -12435,6 +12491,17 @@
       "integrity": "sha512-g9yhqoedzIUm0nTnTqAQvueMPVOuIY16bqgAJJC8XOOubYFNwz6IER9qs0Gq2Xd0+CecCKFjtdDTMA4u4xG06Q==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/node-html-parser": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/node-html-parser/-/node-html-parser-7.1.0.tgz",
+      "integrity": "sha512-iJo8b2uYGT40Y8BTyy5ufL6IVbN8rbm/1QK2xffXU/1a/v3AAa0d1YAoqBNYqaS4R/HajkWIpIfdE6KcyFh1AQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "css-select": "^5.1.0",
+        "he": "1.2.0"
+      }
     },
     "node_modules/node-mock-http": {
       "version": "1.0.4",

--- a/package.json
+++ b/package.json
@@ -99,7 +99,7 @@
     "@astrojs/mdx": "^6.0.3",
     "@babel/core": "^7.29.7",
     "@babel/preset-env": "^7.29.7",
-    "@coreui/astro-docs": "^0.1.0-beta.9",
+    "@coreui/astro-docs": "0.1.0-beta.12",
     "@eslint/markdown": "^7.5.1",
     "@popperjs/core": "^2.11.8",
     "@rollup/plugin-babel": "^7.1.0",


### PR DESCRIPTION
Bumps the shared docs engine pin to `0.1.0-beta.12` (exact — pre-1.0).