### PR TITLE
refactor(util/sanitizer): add shared escapeHtml and SVGAllowlist

### DIFF
--- a/js/src/util/sanitizer.js
+++ b/js/src/util/sanitizer.js
@@ -49,6 +49,47 @@ export const DefaultAllowlist = {
 }
 // js-docs-end allow-list
 
+// js-docs-start svg-allow-list
+export const SVGAllowlist = {
+  ...DefaultAllowlist,
+  svg: ['xmlns', 'version', 'baseprofile', 'width', 'height', 'viewbox', 'preserveaspectratio', 'aria-hidden', 'role', 'focusable', 'fill', 'stroke', 'stroke-width', 'stroke-linecap', 'stroke-linejoin'],
+  g: ['id', 'class', 'transform', 'style'],
+  path: ['id', 'class', 'd', 'fill', 'fill-opacity', 'fill-rule', 'stroke', 'stroke-width', 'stroke-linecap', 'stroke-linejoin', 'stroke-miterlimit', 'stroke-dasharray', 'stroke-dashoffset', 'stroke-opacity'],
+  circle: ['id', 'class', 'cx', 'cy', 'r', 'fill', 'fill-opacity', 'stroke', 'stroke-width', 'stroke-opacity'],
+  rect: ['id', 'class', 'x', 'y', 'width', 'height', 'rx', 'ry', 'fill', 'fill-opacity', 'stroke', 'stroke-width', 'stroke-opacity'],
+  ellipse: ['id', 'class', 'cx', 'cy', 'rx', 'ry', 'fill', 'fill-opacity', 'stroke', 'stroke-width', 'stroke-opacity'],
+  line: ['id', 'class', 'x1', 'y1', 'x2', 'y2', 'stroke', 'stroke-width', 'stroke-linecap', 'stroke-opacity'],
+  polygon: ['id', 'class', 'points', 'fill', 'fill-opacity', 'stroke', 'stroke-width', 'stroke-opacity'],
+  polyline: ['id', 'class', 'points', 'fill', 'fill-opacity', 'stroke', 'stroke-width', 'stroke-opacity'],
+  text: ['id', 'class', 'x', 'y', 'dx', 'dy', 'text-anchor', 'font-family', 'font-size', 'font-weight', 'fill', 'fill-opacity', 'stroke', 'stroke-width', 'stroke-opacity'],
+  tspan: ['id', 'class', 'x', 'y', 'dx', 'dy', 'text-anchor', 'font-family', 'font-size', 'font-weight', 'fill', 'fill-opacity', 'stroke', 'stroke-width', 'stroke-opacity'],
+  defs: [],
+  symbol: ['id', 'class', 'viewbox', 'preserveaspectratio'],
+  use: ['id', 'class', 'x', 'y', 'width', 'height', 'href'],
+  image: ['id', 'class', 'x', 'y', 'width', 'height', 'href', 'preserveaspectratio', 'xlink:href'],
+  pattern: ['id', 'class', 'x', 'y', 'width', 'height', 'patternunits', 'patterncontentunits', 'patterntransform', 'preserveaspectratio'],
+  lineargradient: ['id', 'class', 'gradientunits', 'x1', 'y1', 'x2', 'y2', 'spreadmethod', 'gradienttransform'],
+  radialgradient: ['id', 'class', 'gradientunits', 'cx', 'cy', 'r', 'fx', 'fy', 'spreadmethod', 'gradienttransform'],
+  mask: ['id', 'class', 'x', 'y', 'width', 'height', 'maskunits', 'maskcontentunits', 'masktransform'],
+  clippath: ['id', 'class', 'clippathunits'],
+  marker: ['id', 'class', 'markerunits', 'markerwidth', 'markerheight', 'orient', 'preserveaspectratio', 'viewbox', 'refx', 'refy'],
+  title: [],
+  desc: []
+}
+// js-docs-end svg-allow-list
+
+const ESCAPE_HTML_MAP = {
+  '&': '&amp;',
+  '<': '&lt;',
+  '>': '&gt;',
+  '"': '&quot;',
+  "'": '&#x27;'
+}
+
+export function escapeHtml(unsafeText) {
+  return String(unsafeText).replace(/[&<>"']/g, character => ESCAPE_HTML_MAP[character])
+}
+
 const uriAttributes = new Set([
   'background',
   'cite',

--- a/js/tests/unit/util/sanitizer.spec.js
+++ b/js/tests/unit/util/sanitizer.spec.js
@@ -1,6 +1,28 @@
-import { DefaultAllowlist, sanitizeHtml } from '../../../src/util/sanitizer.js'
+import {
+  DefaultAllowlist, escapeHtml, sanitizeHtml, SVGAllowlist
+} from '../../../src/util/sanitizer.js'
 
 describe('Sanitizer', () => {
+  describe('escapeHtml', () => {
+    it('should escape HTML-significant characters', () => {
+      expect(escapeHtml('<img src="x" onerror=\'alert(1)\'> & more'))
+        .toEqual('&lt;img src=&quot;x&quot; onerror=&#x27;alert(1)&#x27;&gt; &amp; more')
+    })
+
+    it('should leave plain text untouched', () => {
+      expect(escapeHtml('Water and Fire')).toEqual('Water and Fire')
+    })
+  })
+
+  describe('SVGAllowlist', () => {
+    it('should extend the default allow list with SVG elements', () => {
+      expect(SVGAllowlist.div).toEqual(DefaultAllowlist.div)
+      expect(SVGAllowlist.svg).toContain('viewbox')
+      expect(SVGAllowlist.path).toContain('d')
+      expect(SVGAllowlist.line).toContain('x1')
+    })
+  })
+
   describe('sanitizeHtml', () => {
     it('should return the same on empty string', () => {
       const empty = ''


### PR DESCRIPTION
## Refactor — shared sanitizer primitives

Foundational for the Chip icon-sanitizer fix (#1117). Adds two reusable primitives to `util/sanitizer.js`, next to `sanitizeHtml` / `DefaultAllowlist`:

- **`escapeHtml(text)`** — HTML-escape a string (safe for attribute values and text content).
- **`SVGAllowlist`** — `DefaultAllowlist` extended with SVG elements, consumed by Chip's icon sanitizer instead of a component-local copy.

Kept **byte-identical** to the Pro edition's `util/sanitizer.js` (coreui-pro#597) so the free → pro sync stays conflict-free. #1117 is stacked on this branch.