### PR TITLE
fix(Chip): sanitize selected/remove icons before injection

### DIFF
--- a/js/src/chip.js
+++ b/js/src/chip.js
@@ -7,7 +7,9 @@
 
 import BaseComponent from './base-component.js'
 import EventHandler from './dom/event-handler.js'
+import Manipulator from './dom/manipulator.js'
 import SelectorEngine from './dom/selector-engine.js'
+import { sanitizeHtml, SVGAllowlist } from './util/sanitizer.js'
 import { defineJQueryPlugin } from './util/index.js'
 
 /**
@@ -39,23 +41,31 @@ const CLASS_NAME_DISABLED = 'disabled'
 const DEFAULT_REMOVE_ICON = '<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><line x1="4" y1="4" x2="12" y2="12"/><line x1="12" y1="4" x2="4" y2="12"/></svg>'
 const DEFAULT_SELECTED_ICON = '<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 512 512" fill="currentColor"><path d="M425.373 89.373 196 318.745 86.627 209.373l-45.254 45.254L196 409.255l274.627-274.628z"/></svg>'
 
+const DISALLOWED_ATTRIBUTES = new Set(['sanitize', 'allowList', 'sanitizeFn'])
+
 const Default = {
+  allowList: SVGAllowlist,
   ariaRemoveLabel: 'Remove',
   disabled: false,
   filter: false,
   removable: false,
   removeIcon: DEFAULT_REMOVE_ICON,
+  sanitize: true,
+  sanitizeFn: null,
   selectable: false,
   selected: false,
   selectedIcon: DEFAULT_SELECTED_ICON
 }
 
 const DefaultType = {
+  allowList: 'object',
   ariaRemoveLabel: 'string',
   disabled: 'boolean',
   filter: 'boolean',
   removable: 'boolean',
   removeIcon: 'string',
+  sanitize: 'boolean',
+  sanitizeFn: '(null|function)',
   selectable: 'boolean',
   selected: 'boolean',
   selectedIcon: 'string'
@@ -232,7 +242,7 @@ class Chip extends BaseComponent {
     const check = document.createElement('span')
     check.className = CLASS_NAME_CHIP_CHECK
     check.setAttribute('aria-hidden', 'true')
-    check.innerHTML = this._config.selectedIcon
+    check.innerHTML = this._sanitizeIcon(this._config.selectedIcon)
     this._element.prepend(check)
   }
 
@@ -242,7 +252,7 @@ class Chip extends BaseComponent {
     button.className = CLASS_NAME_CHIP_REMOVE
     button.setAttribute('aria-label', this._config.ariaRemoveLabel)
     button.setAttribute('tabindex', '-1') // Not in tab order, chips handle keyboard
-    button.innerHTML = this._config.removeIcon
+    button.innerHTML = this._sanitizeIcon(this._config.removeIcon)
     return button
   }
 
@@ -304,6 +314,30 @@ class Chip extends BaseComponent {
     EventHandler.trigger(this._element, EVENT_REMOVED)
     this._element.remove()
     this.dispose()
+  }
+
+  _sanitizeIcon(icon) {
+    return this._config.sanitize ? sanitizeHtml(icon, this._config.allowList, this._config.sanitizeFn) : icon
+  }
+
+  _getConfig(config) {
+    const dataAttributes = Manipulator.getDataAttributes(this._element)
+
+    for (const dataAttribute of Object.keys(dataAttributes)) {
+      if (DISALLOWED_ATTRIBUTES.has(dataAttribute)) {
+        delete dataAttributes[dataAttribute]
+      }
+    }
+
+    config = {
+      ...dataAttributes,
+      ...(typeof config === 'object' && config ? config : {})
+    }
+    config = this._mergeConfigObj(config)
+    config = this._configAfterMerge(config)
+    this._typeCheckConfig(config)
+
+    return config
   }
 
   // Static

--- a/js/tests/unit/chip.spec.js
+++ b/js/tests/unit/chip.spec.js
@@ -341,6 +341,62 @@ describe('Chip', () => {
     })
   })
 
+  describe('sanitize', () => {
+    it('should strip event-handler attributes from a custom removeIcon', () => {
+      fixtureEl.innerHTML = '<span class="chip">Tag</span>'
+
+      const chipEl = fixtureEl.querySelector('.chip')
+      // eslint-disable-next-line no-new
+      new Chip(chipEl, { removable: true, removeIcon: '<img src=x onerror="window.xss = true"> x' })
+
+      const btn = chipEl.querySelector('.chip-remove')
+      expect(btn.querySelector('img').hasAttribute('onerror')).toBeFalse()
+      expect(btn.textContent).toContain('x')
+    })
+
+    it('should strip disallowed markup from a custom selectedIcon', () => {
+      fixtureEl.innerHTML = '<span class="chip active">Tag</span>'
+
+      const chipEl = fixtureEl.querySelector('.chip')
+      // eslint-disable-next-line no-new
+      new Chip(chipEl, { selectable: true, filter: true, selectedIcon: '<svg><script>window.xss = true</script></svg>' })
+
+      const check = chipEl.querySelector('.chip-check')
+      expect(check.querySelector('script')).toBeNull()
+    })
+
+    it('should keep the raw icon when sanitize is false', () => {
+      fixtureEl.innerHTML = '<span class="chip">Tag</span>'
+
+      const chipEl = fixtureEl.querySelector('.chip')
+      // eslint-disable-next-line no-new
+      new Chip(chipEl, { removable: true, sanitize: false, removeIcon: '<span class="raw-icon"></span>' })
+
+      expect(chipEl.querySelector('.chip-remove .raw-icon')).not.toBeNull()
+    })
+
+    it('should render the default icons after sanitization', () => {
+      fixtureEl.innerHTML = '<span class="chip active">Tag</span>'
+
+      const chipEl = fixtureEl.querySelector('.chip')
+      // eslint-disable-next-line no-new
+      new Chip(chipEl, { removable: true, selectable: true, filter: true })
+
+      expect(chipEl.querySelector('.chip-remove svg line')).not.toBeNull()
+      expect(chipEl.querySelector('.chip-check svg path')).not.toBeNull()
+    })
+
+    it('should not disable sanitization via a data attribute', () => {
+      fixtureEl.innerHTML = '<span class="chip" data-coreui-sanitize="false" data-coreui-removable="true" data-coreui-remove-icon="<img src=x onerror=alert(1)>">Tag</span>'
+
+      const chipEl = fixtureEl.querySelector('.chip')
+      const chip = new Chip(chipEl)
+
+      expect(chip._config.sanitize).toBeTrue()
+      expect(chipEl.querySelector('.chip-remove img').hasAttribute('onerror')).toBeFalse()
+    })
+  })
+
   describe('select', () => {
     it('should add active class and set aria-selected when selected', () => {
       fixtureEl.innerHTML = '<span class="chip">Tag</span>'


### PR DESCRIPTION
## Security fix — Chip icons injected with no sanitizer

`selectedIcon` and `removeIcon` (settable via `data-coreui-*` attributes) were written to `innerHTML` with no sanitizer, unlike `rating.js`.

### Fix
- Add `sanitize` / `allowList` / `sanitizeFn` options (using the shared `SVGAllowlist`) mirroring `rating.js`.
- Route both icons through `_sanitizeIcon` → `sanitizeHtml`.
- Strip `sanitize` / `allowList` / `sanitizeFn` from the element's data attributes so the sanitizer can't be disabled from markup (`_mergeConfigObj` without the element, as `tooltip.js` does).

Framework ports (React/Vue) render these as `ReactNode`/VNode with no `innerHTML` sink and are not affected. Regression tests added.

_(Supersedes #1117, which was auto-closed when its base branch `refactor/shared-sanitizer-utils` was deleted after #1118 merged; same branch, now retargeted to `main`.)_