### PR TITLE
fix: avoid Array.prototype.at() to support the declared browser range

### DIFF
--- a/js/src/chip-input.js
+++ b/js/src/chip-input.js
@@ -166,7 +166,7 @@ class ChipInput extends ChipSet {
       // direction is mirrored in RTL.
       if (event.key === (isRTL() ? 'ArrowLeft' : 'ArrowRight')) {
         const chips = this._getFocusableChips()
-        if (chips.length > 0 && chips.at(-1).contains(event.target)) {
+        if (chips.length > 0 && chips[chips.length - 1].contains(event.target)) {
           event.preventDefault()
           this._input.focus()
           return
@@ -271,7 +271,7 @@ class ChipInput extends ChipSet {
           const chips = this._getChipElements()
 
           if (chips.length > 0) {
-            chips.at(-1).focus()
+            chips[chips.length - 1].focus()
           }
         }
 
@@ -292,7 +292,7 @@ class ChipInput extends ChipSet {
           const chips = this._getChipElements()
 
           if (chips.length > 0) {
-            chips.at(-1).focus()
+            chips[chips.length - 1].focus()
           }
         }
 
@@ -323,7 +323,7 @@ class ChipInput extends ChipSet {
         this.add(part.trim())
       }
 
-      this._input.value = parts.at(-1)
+      this._input.value = parts[parts.length - 1]
     }
 
     this._setInputSize()

--- a/js/src/chip-set.js
+++ b/js/src/chip-set.js
@@ -428,7 +428,7 @@ class ChipSet extends BaseComponent {
 
   _navigateToEdge(targetIndex) {
     const chips = this._getFocusableChips()
-    chips.at(targetIndex)?.focus()
+    chips[targetIndex < 0 ? chips.length + targetIndex : targetIndex]?.focus()
   }
 
   _handleSelectionChange(event) {


### PR DESCRIPTION
The build ships a runnable bundle for the browsers declared in `.browserslistrc` (Chrome >= 60, Safari >= 12, iOS >= 12) and does not polyfill (no `useBuiltIns`). `Array.prototype.at()` requires Chrome 92 / Safari 15.4 / iOS 15.4, so it throws on the supported older browsers.

Replace all `.at()` usages in `js/src` with index access:

- `chip-input.js` — `chips.at(-1)` / `parts.at(-1)` → index access (×4)
- `chip-set.js` — `chips.at(targetIndex)` → `chips[targetIndex < 0 ? chips.length + targetIndex : targetIndex]` (preserves negative-index semantics)

Behavior unchanged; existing suites pass (1111). Pro counterpart: coreui/coreui-pro (also covers the calendar util).