### PR TITLE
chore: remove unused config.version_short from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,9 +2,6 @@
   "name": "@coreui/coreui",
   "description": "The most popular front-end framework for developing responsive, mobile-first projects on the web rewritten and maintained by the CoreUI Team",
   "version": "5.8.0",
-  "config": {
-    "version_short": "5.7"
-  },
   "keywords": [
     "css",
     "sass",


### PR DESCRIPTION
Leftover from the Bootstrap fork. Nothing reads `config.version_short` — no build script, docs config, or `npm_package_config_*` consumer — since the docs moved from Hugo to Astro (the old Hugo docs used a separate `docs_version` param, not this field).