### PR TITLE
docs: remove React references from the Bootstrap templates page

### DIFF
--- a/docs/src/content/docs/templates/admin-dashboard.mdx
+++ b/docs/src/content/docs/templates/admin-dashboard.mdx
@@ -1,11 +1,11 @@
 ---
 title: "Bootstrap Templates"
-description: "Develop modern, beautiful, and responsive applications in half the time with high-performing and easy-to-customize react admin panels to cover any requirement."
+description: "Develop modern, beautiful, and responsive applications in half the time with high-performing and easy-to-customize Bootstrap admin panels to cover any requirement."
 ---
 
 ## Bootstrap Admin & Dashboard Templates
 
-Check out the fully-featured, ready-to-use admin dashboard templates built using CoreUI for React.js, and CoreUI PRO for React.js
+Check out the fully-featured, ready-to-use admin dashboard templates built using CoreUI, and CoreUI PRO.
 
 <div class="row">
   <div class="col-md-6">


### PR DESCRIPTION
The Bootstrap templates page carried two leftovers from the React docs:

- the meta description advertised "easy-to-customize **react** admin panels",
- the intro read "built using CoreUI for **React.js**, and CoreUI PRO for **React.js**".

`coreui-pro` already has the corrected intro sentence; this brings the free docs in line and fixes the description in both.

`npm run docs-build` passes (121 pages, no broken links). `js-lint` and `css-lint` are clean.

Note: `npm run js-test-karma` exits non-zero with "Some of your tests did a full page reload!" while reporting 1114/1114 SUCCESS — this reproduces on a clean `main` and is unrelated to this docs-only change.