### PR TITLE
fix(Sidebar): stop leaking the document and window listeners

### DIFF
--- a/js/src/sidebar.js
+++ b/js/src/sidebar.js
@@ -64,6 +64,14 @@ class Sidebar extends BaseComponent {
     this._narrow = this._isNarrow()
     this._unfoldable = this._isUnfoldable()
     this._backdrop = this._initializeBackDrop()
+    this._clickOutHandler = event => this._clickOutListener(event)
+    this._resizeHandler = () => {
+      if (this._isMobile() && this._isVisible()) {
+        this.hide()
+        this._backdrop = this._initializeBackDrop()
+      }
+    }
+
     this._addEventListeners()
   }
 
@@ -199,6 +207,13 @@ class Sidebar extends BaseComponent {
     this.unfoldable()
   }
 
+  dispose() {
+    this._removeClickOutListener()
+    EventHandler.off(window, EVENT_RESIZE, this._resizeHandler)
+
+    super.dispose()
+  }
+
   // Private
 
   _initializeBackDrop() {
@@ -243,13 +258,11 @@ class Sidebar extends BaseComponent {
   }
 
   _addClickOutListener() {
-    EventHandler.on(document, EVENT_CLICK_DATA_API, event => {
-      this._clickOutListener(event)
-    })
+    EventHandler.on(document, EVENT_CLICK_DATA_API, this._clickOutHandler)
   }
 
   _removeClickOutListener() {
-    EventHandler.off(document, EVENT_CLICK_DATA_API)
+    EventHandler.off(document, EVENT_CLICK_DATA_API, this._clickOutHandler)
   }
 
   // Sidebar navigation
@@ -280,12 +293,7 @@ class Sidebar extends BaseComponent {
       this.hide()
     })
 
-    EventHandler.on(window, EVENT_RESIZE, () => {
-      if (this._isMobile() && this._isVisible()) {
-        this.hide()
-        this._backdrop = this._initializeBackDrop()
-      }
-    })
+    EventHandler.on(window, EVENT_RESIZE, this._resizeHandler)
   }
 
   // Static

--- a/js/tests/unit/sidebar.spec.js
+++ b/js/tests/unit/sidebar.spec.js
@@ -376,6 +376,63 @@ describe('Sidebar', () => {
     })
   })
 
+  describe('dispose', () => {
+    it('should drop its window resize listener', () => {
+      fixtureEl.innerHTML = '<div class="sidebar"></div>'
+
+      const el = fixtureEl.querySelector('.sidebar')
+      const sidebar = new Sidebar(el)
+
+      // Watch the prototype and match on the receiver: `dispose()` nulls the
+      // instance's own properties (an instance spy would be wiped), and other
+      // sidebars in this file may still hold their own resize listeners.
+      const original = Sidebar.prototype._isMobile
+      let calledOnDisposedInstance = false
+      Sidebar.prototype._isMobile = function (...args) {
+        if (this === sidebar) {
+          calledOnDisposedInstance = true
+        }
+
+        return original.apply(this, args)
+      }
+
+      try {
+        sidebar.dispose()
+        window.dispatchEvent(new Event('resize'))
+      } finally {
+        Sidebar.prototype._isMobile = original
+      }
+
+      expect(calledOnDisposedInstance).toBeFalse()
+    })
+
+    it('should remove the click out listener', () => {
+      fixtureEl.innerHTML = '<div class="sidebar"></div><input type="checkbox" class="outside">'
+      const sidebar = new Sidebar('.sidebar')
+      const outsideEl = fixtureEl.querySelector('.outside')
+      const spyHide = spyOn(sidebar, 'hide')
+
+      sidebar._addClickOutListener()
+      sidebar.dispose()
+      outsideEl.click()
+
+      expect(spyHide).not.toHaveBeenCalled()
+      expect(outsideEl.checked).toBeTrue()
+    })
+
+    it('should keep the window load data api handler', () => {
+      fixtureEl.innerHTML = '<div class="sidebar"></div>'
+      const sidebarEl = fixtureEl.querySelector('.sidebar')
+      const sidebar = new Sidebar(sidebarEl)
+      const spySidebarInterface = spyOn(Sidebar, 'sidebarInterface')
+
+      sidebar.dispose()
+      window.dispatchEvent(new Event('load'))
+
+      expect(spySidebarInterface).toHaveBeenCalledWith(sidebarEl)
+    })
+  })
+
   describe('Private Methods', () => {
     describe('_initializeBackDrop', () => {
       it('should create backdrop with correct configuration', () => {
@@ -523,6 +580,41 @@ describe('Sidebar', () => {
         expect(mockEvent.preventDefault).not.toHaveBeenCalled()
         expect(mockEvent.stopPropagation).not.toHaveBeenCalled()
         expect(spyHide).not.toHaveBeenCalled()
+      })
+    })
+
+    describe('_removeClickOutListener', () => {
+      it('should keep the click out listener of another instance', () => {
+        fixtureEl.innerHTML = [
+          '<div class="sidebar first"></div>',
+          '<div class="sidebar second"></div>',
+          '<div class="outside"></div>'
+        ].join('')
+        const first = new Sidebar('.first')
+        const second = new Sidebar('.second')
+        const outsideEl = fixtureEl.querySelector('.outside')
+        const spyFirstHide = spyOn(first, 'hide')
+        const spySecondHide = spyOn(second, 'hide')
+
+        first._addClickOutListener()
+        second._addClickOutListener()
+        second._removeClickOutListener()
+        outsideEl.click()
+
+        expect(spyFirstHide).toHaveBeenCalled()
+        expect(spySecondHide).not.toHaveBeenCalled()
+      })
+
+      it('should not prevent a click outside once every listener is removed', () => {
+        fixtureEl.innerHTML = '<div class="sidebar"></div><input type="checkbox" class="outside">'
+        const sidebar = new Sidebar('.sidebar')
+        const outsideEl = fixtureEl.querySelector('.outside')
+
+        sidebar._addClickOutListener()
+        sidebar._removeClickOutListener()
+        outsideEl.click()
+
+        expect(outsideEl.checked).toBeTrue()
       })
     })
 


### PR DESCRIPTION
`show()` registers a click-out listener on `document` that `preventDefault()`s and `stopPropagation()`s every click landing outside `.sidebar`. It was registered as an anonymous closure, so nothing could remove that exact handler:

- `dispose()` never removed it — the component had no `dispose()` at all — so a disposed sidebar keeps cancelling clicks across the whole document and calling `hide()` on itself
- `_removeClickOutListener()` fell back to `EventHandler.off(document, EVENT_CLICK_DATA_API)` with no handler, which removes every sidebar-namespaced click handler on `document`, so hiding one sidebar disabled the click-out of any other instance

Both listeners now go through stable references held on the instance, and `dispose()` removes them before delegating to `BaseComponent`. The window resize listener gets the same treatment — it was leaking too.

This is also what made the suite flaky under Karma, where every spec shares one document: a sidebar spec left an instance behind, its leaked listener `preventDefault()`ed a later spec’s checkbox click, and `<Component> data-api should not prevent event for input` failed in Offcanvas or Collapse. That is the failure that turned `main` red 6 times in the last 40 JS runs. Vitest’s per-file isolation (#PLACEHOLDER) contains the symptom; this fixes the cause, which was real in a browser too.

Three specs cover it, all of which fail on the sources before this change:

- `_removeClickOutListener > should keep the click out listener of another instance`
- `dispose > should remove the click out listener`
- `dispose > should keep the window load data api handler`

The v6 line has the same defect plus a second one in its own `dispose()`; fixed in coreui/coreui-pro#687.