### PR TITLE
docs: add Data Grid section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ Whether you're starting a new project or migrating from Bootstrap, CoreUI gives 
 - [Frameworks](#frameworks)
 - [Templates](#templates)
 - [Templates](#boilerplates)
+- [Data Grid](#data-grid)
 - [Contributing](#contributing)
 - [Community](#community)
 - [Versioning](#versioning)
@@ -231,6 +232,19 @@ Fully featured, out-of-the-box, templates for your application based on CoreUI.
 ## Boilerplates
 
 - [AI-Native Next.js Boilerplate for Internal Tools](https://coreui.io/product/next-js-boilerplate/)
+
+## Data Grid
+
+CoreUI JavaScript Data Grid handles 100,000+ rows with sorting, filtering, virtualization, column pinning, inline editing and CSV export — using the same markup and stylesheet you already use.
+
+```bash
+npm install @coreui/data-grid
+```
+
+One license also covers React, Vue and Angular. It's a separate add-on, not part of CoreUI PRO.
+
+- [JavaScript Data Grid](https://coreui.io/data-grid/javascript/?src=readme-coreui)
+- [Documentation](https://coreui.io/data-grid/docs/getting-started/introduction/?src=readme-coreui)
 
 ## Contributing
 


### PR DESCRIPTION
Adds a Data Grid section to the README.

**Why:** attach rate for Data Grid on our own install base is 0.04%. `@coreui/coreui`
and `@coreui/react` together do ~1.16M npm downloads a month; the Data Grid packages do
~1.7k. The README already promotes PRO (22–29 mentions) but never mentioned Data Grid at all.

**Framework-targeted:** each README links to its own variant — the Vue README points at
Vue Data Grid, `/data-grid/vue/` and `npm install @coreui/vue-data-grid` — so the reader
is not asked to pick. The "one license also covers …" line stays in every variant, because
multi-framework coverage is the differentiator MUI X (React only), AG Grid (separate
packages per framework) and TanStack (headless) cannot match.

**Attribution:** links carry `?src=` for first-touch tracking, matching the convention
already used in the demos. Without it the traffic lands in Direct and the change cannot
be measured.

Table of contents updated — they are maintained by hand.

All target URLs verified to return HTTP 200.