### PR TITLE
fix(Card): square the trailing footer corner of a card in a card group

### DIFF
--- a/scss/_card.scss
+++ b/scss/_card.scss
@@ -233,7 +233,7 @@
             border-top-left-radius: 0;
           }
           > .card-img-bottom,
-          > card-footer {
+          > .card-footer {
             // stylelint-disable-next-line property-disallowed-list
             border-bottom-left-radius: 0;
           }


### PR DESCRIPTION
The rule squaring the leading corners of every card after the first in a `.card-group` was written `> card-footer`, without the leading dot, so it matched an element type that does not exist and never applied.

Effect: the footer of each such card kept a rounded bottom-left corner while the rest of its edge ran flush into the previous card. Measured bottom-left radius on the second card's footer goes from 5px to 0.

Inherited from Bootstrap 5, where the same typo is present.