### PR TITLE
chore(deps): bump @coreui/astro-docs to 0.1.10

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "@astrojs/mdx": "^7.0.4",
         "@babel/core": "^7.29.7",
         "@babel/preset-env": "^7.29.7",
-        "@coreui/astro-docs": "0.1.9",
+        "@coreui/astro-docs": "0.1.10",
         "@eslint/markdown": "^7.5.1",
         "@popperjs/core": "^2.11.8",
         "@rollup/plugin-babel": "^7.1.0",
@@ -2204,9 +2204,9 @@
       }
     },
     "node_modules/@coreui/astro-docs": {
-      "version": "0.1.9",
-      "resolved": "https://registry.npmjs.org/@coreui/astro-docs/-/astro-docs-0.1.9.tgz",
-      "integrity": "sha512-gNxj5Lakojwxog6LnLroX0J7so3gKZSilenNv4B7viQ1ERbA+Qkc5at+dfCzdNU8wJQU7yx1FUKChLsel9fNcw==",
+      "version": "0.1.10",
+      "resolved": "https://registry.npmjs.org/@coreui/astro-docs/-/astro-docs-0.1.10.tgz",
+      "integrity": "sha512-o2egGMTwqlmK3SoDo00ffqWobcsEZ+miEskeZ2+/QJp+bk87S5JojTBw6Bk5L+JjuJXfEwbklRwtz+r1qXghDA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -95,7 +95,7 @@
     "@astrojs/mdx": "^7.0.4",
     "@babel/core": "^7.29.7",
     "@babel/preset-env": "^7.29.7",
-    "@coreui/astro-docs": "0.1.9",
+    "@coreui/astro-docs": "0.1.10",
     "@eslint/markdown": "^7.5.1",
     "@popperjs/core": "^2.11.8",
     "@rollup/plugin-babel": "^7.1.0",


### PR DESCRIPTION
Picks up `@coreui/astro-docs@0.1.10`, published today. Three changes since `0.1.9`:

- the header sticks and the footer keeps its surface on a v6 site, after v6 dropped `.header-sticky` and `.footer` (coreui/astro-docs#87)
- the deprecated badge in API tables keeps only `Deprecated` plus a leading version; the explanation wraps below (coreui/astro-docs#82)
- `<Code filePath fileMatch />` reads a block from a built file (coreui/astro-docs#84)

One line in `package.json` plus the reconciled lockfile.
