### PR TITLE
chore(deps): bump @coreui/astro-docs to 0.1.11

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "@astrojs/mdx": "^7.0.4",
         "@babel/core": "^7.29.7",
         "@babel/preset-env": "^7.29.7",
-        "@coreui/astro-docs": "0.1.10",
+        "@coreui/astro-docs": "0.1.11",
         "@eslint/markdown": "^7.5.1",
         "@popperjs/core": "^2.11.8",
         "@rollup/plugin-babel": "^7.1.0",
@@ -2204,9 +2204,9 @@
       }
     },
     "node_modules/@coreui/astro-docs": {
-      "version": "0.1.10",
-      "resolved": "https://registry.npmjs.org/@coreui/astro-docs/-/astro-docs-0.1.10.tgz",
-      "integrity": "sha512-o2egGMTwqlmK3SoDo00ffqWobcsEZ+miEskeZ2+/QJp+bk87S5JojTBw6Bk5L+JjuJXfEwbklRwtz+r1qXghDA==",
+      "version": "0.1.11",
+      "resolved": "https://registry.npmjs.org/@coreui/astro-docs/-/astro-docs-0.1.11.tgz",
+      "integrity": "sha512-H3RRoqDExoFbXHtqnbRrYOU5owzMTabNNzpKrJTHvK93i2yw2vF4VA3CgO61guXa7ZJs9MmBWX87sVSNe7M6RQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -95,7 +95,7 @@
     "@astrojs/mdx": "^7.0.4",
     "@babel/core": "^7.29.7",
     "@babel/preset-env": "^7.29.7",
-    "@coreui/astro-docs": "0.1.10",
+    "@coreui/astro-docs": "0.1.11",
     "@eslint/markdown": "^7.5.1",
     "@popperjs/core": "^2.11.8",
     "@rollup/plugin-babel": "^7.1.0",


### PR DESCRIPTION
Carries coreui/astro-docs#89 — the docs chrome stops assuming the consuming library's palette is a legacy Sass colour. No rendered change on this line.