### PR TITLE
chore(docs): bump @coreui/astro-docs to 0.1.12

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "@astrojs/mdx": "^7.0.4",
         "@babel/core": "^7.29.7",
         "@babel/preset-env": "^7.29.7",
-        "@coreui/astro-docs": "0.1.11",
+        "@coreui/astro-docs": "0.1.12",
         "@eslint/markdown": "^7.5.1",
         "@popperjs/core": "^2.11.8",
         "@rollup/plugin-babel": "^7.1.0",
@@ -2204,9 +2204,9 @@
       }
     },
     "node_modules/@coreui/astro-docs": {
-      "version": "0.1.11",
-      "resolved": "https://registry.npmjs.org/@coreui/astro-docs/-/astro-docs-0.1.11.tgz",
-      "integrity": "sha512-H3RRoqDExoFbXHtqnbRrYOU5owzMTabNNzpKrJTHvK93i2yw2vF4VA3CgO61guXa7ZJs9MmBWX87sVSNe7M6RQ==",
+      "version": "0.1.12",
+      "resolved": "https://registry.npmjs.org/@coreui/astro-docs/-/astro-docs-0.1.12.tgz",
+      "integrity": "sha512-loGvEZrHkX7CV1of2jF7oJOoT2LGOAORFXnxnzM/yU6Oa8N5og0SObjUmGTXSY7YgEtqogGr9NKp2EmXq/xgMA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -95,7 +95,7 @@
     "@astrojs/mdx": "^7.0.4",
     "@babel/core": "^7.29.7",
     "@babel/preset-env": "^7.29.7",
-    "@coreui/astro-docs": "0.1.11",
+    "@coreui/astro-docs": "0.1.12",
     "@eslint/markdown": "^7.5.1",
     "@popperjs/core": "^2.11.8",
     "@rollup/plugin-babel": "^7.1.0",


### PR DESCRIPTION
Bumps the docs engine pin from 0.1.11 to 0.1.12.

Gate: `npm run docs-build` passes, engine still detects edition FREE and builds in `styles mode: full`.